### PR TITLE
Add common result for REST API

### DIFF
--- a/src/minirest.erl
+++ b/src/minirest.erl
@@ -21,8 +21,14 @@
 
 -export([handler/1]).
 
+-export([ return/0
+        , return/1
+        ]).
+
 %% Cowboy callback
 -export([init/2]).
+
+-define(SUCCESS, 0).
 
 -type(option() :: {authorization, fun()}).
 -type(handler() :: {string(), mfa()} | {string(), mfa(), list(option())}).
@@ -30,6 +36,10 @@
 -export_type([ option/0
              , handler/0
              ]).
+
+%%------------------------------------------------------------------------------
+%% Start/Stop Http
+%%------------------------------------------------------------------------------
 
 -spec(start_http(atom(), list(), list()) -> {ok, pid()}).
 start_http(ServerName, Options, Handlers) ->
@@ -43,6 +53,10 @@ start_https(ServerName, Options, Handlers) ->
     {ok, _} = cowboy:start_tls(ServerName, Options, #{env => #{dispatch => Dispatch}}),
     io:format("Start ~s listener on ~p successfully.~n", [ServerName, proplists:get_value(port, Options)]).
 
+-spec(stop_http(atom()) -> ok).
+stop_http(ServerName) ->
+    cowboy:stop_listener(ServerName).
+
 map({Prefix, MFArgs}) ->
     map({Prefix, MFArgs, []});
 map({Prefix, MFArgs, Options}) ->
@@ -54,16 +68,20 @@ handlers(Handlers) ->
         (Handler) -> Handler
     end, Handlers).
 
-init(Req, Opts) ->
-    Req1 = handle_request(Req, Opts),
-    {ok, Req1, Opts}.
+%%------------------------------------------------------------------------------
+%% Handler helper
+%%------------------------------------------------------------------------------
 
 -spec(handler(minirest_handler:config()) -> handler()).
 handler(Config) -> minirest_handler:init(Config).
 
--spec(stop_http(atom()) -> ok).
-stop_http(ServerName) ->
-    cowboy:stop_listener(ServerName).
+%%------------------------------------------------------------------------------
+%% Cowboy callbacks
+%%------------------------------------------------------------------------------
+
+init(Req, Opts) ->
+    Req1 = handle_request(Req, Opts),
+    {ok, Req1, Opts}.
 
 %% Callback
 handle_request(Req, Handlers) ->
@@ -107,4 +125,31 @@ internal_error(Req, Error, Stacktrace) ->
     error_logger:error_msg("~s ~s error: ~p, stacktrace:~n~p",
                            [cowboy_req:method(Req), cowboy_req:path(Req), Error, Stacktrace]),
     cowboy_req:reply(500, #{<<"content-type">> => <<"text/plain">>}, <<"Internal Error">>, Req).
+
+%%------------------------------------------------------------------------------
+%% Return
+%%------------------------------------------------------------------------------
+
+return() ->
+    {ok, [{code, ?SUCCESS}]}.
+
+return({ok, #{data := Data, meta := Meta}}) ->
+    {ok, [{code, ?SUCCESS},
+          {data, Data},
+          {meta, Meta}]};
+return({ok, Data}) ->
+    {ok, [{code, ?SUCCESS},
+          {data, Data}]};
+return({ok, Code, Message}) when is_integer(Code) ->
+    {ok, [{code,    Code},
+          {message, Message}]};
+return({ok, Data, Meta}) ->
+    {ok, [{code, ?SUCCESS},
+          {data, Data},
+          {meta, Meta}]};
+return({error, Message}) ->
+    {ok, [{message, Message}]};
+return({error, Code, Message}) ->
+    {ok, [{code,    Code},
+          {message, Message}]}.
 

--- a/test/minirest_SUITE.erl
+++ b/test/minirest_SUITE.erl
@@ -20,7 +20,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->
-    [{group, handler}, {group, rest}, {group, rest_app}].
+    [{group, handler}, {group, rest}, {group, rest_app}, t_return].
 
 groups() ->
     [{handler,  [sequence], [t_init]},
@@ -90,6 +90,27 @@ t_delete(_Config) ->
 
 t_auth(_Config) ->
     {ok, {{_, 401, _}, _Headers, _Body}} = json_request(delete, "http://127.0.0.1:8080/api/v2/books/1",[], [auth_header_("admin1", "public")]).
+
+t_return(_Config) ->
+    ?assertEqual({ok, [{code, 0}]}, minirest:return()),
+    ?assertEqual({ok, [{code, 0},
+                       {data, <<"data">>},
+                       {meta, #{}}]}, minirest:return({ok, #{data => <<"data">>, meta => #{}}})),
+
+    ?assertEqual({ok, [{code, 0},
+                       {data, <<"data">>}]}, minirest:return({ok, <<"data">>})),
+
+    ?assertEqual({ok, [{code, 1001},
+                       {message, <<"message">>}]}, minirest:return({ok, 1001, <<"message">>})),
+
+    ?assertEqual({ok, [{code, 0},
+                       {data, <<"data">>},
+                       {meta, <<"meta">>}]}, minirest:return({ok, <<"data">>, <<"meta">>})),
+
+    ?assertEqual({ok, [{message, <<"message">>}]}, minirest:return({error, <<"message">>})),
+    ?assertEqual({ok, [{code, 1001},
+                       {message, <<"message">>}]}, minirest:return({error, 1001, <<"message">>})).
+
 
 httpc_get(Url) ->
     httpc:request(get, {Url, []}, [], [{body_format, binary}]).

--- a/test/minirest_SUITE.erl
+++ b/test/minirest_SUITE.erl
@@ -15,6 +15,7 @@
 -module(minirest_SUITE).
 
 -compile(export_all).
+-compile(nowarn_export_all).
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -59,12 +60,12 @@ end_per_group(_Group, _Config) ->
     ok.
 
 t_init(_Config) ->
-    {minirest_handler, dispatch, [Routes]} = minirest:handler(#{modules => [rest_api_books]}),
+    {minirest_handler, dispatch, [Routes, _Filter = undefined]} = minirest:handler(#{modules => [rest_api_books]}),
     ?assertEqual(4, length(Routes)).
 
 t_index(_Config) ->
     {ok, {{_, 200, "OK"}, _Headers, Body}} = httpc_get("http://127.0.0.1:8080/api/v2/"),
-    APIs = jsx:decode(Body, [return_maps]),
+    #{<<"code">> := 0, <<"data">> := APIs} = jsx:decode(Body, [return_maps]),
     ct:print("REST APIs: ~p", [APIs]),
     ?assertEqual(4, length(APIs)).
 
@@ -111,5 +112,4 @@ authorize_appid(Req) ->
             (Username =:= <<"admin">>) and (Password =:= <<"public">>);
          _  -> false
     end.
-
 


### PR DESCRIPTION
Add a return function to unifying generic REST response format:

We can use this fun with the following example:
```erlang
-module(books_rest_api).

-import(minirest, [return/0, return/1]).

-rest_api(xxx).

list(_Binding, _Params) ->
    return(query_book()).

%%
-spec query_book() -> {ok, Books} | {error, Reason}
...
```