### PR TITLE
Improve the return fun to match more cases

### DIFF
--- a/src/minirest.erl
+++ b/src/minirest.erl
@@ -133,6 +133,8 @@ internal_error(Req, Error, Stacktrace) ->
 return() ->
     {ok, [{code, ?SUCCESS}]}.
 
+return(ok) ->
+    {ok, [{code, ?SUCCESS}]};
 return({ok, #{data := Data, meta := Meta}}) ->
     {ok, [{code, ?SUCCESS},
           {data, Data},


### PR DESCRIPTION
I have added a function clause to match more cases (some functions of emqx_management must need this clause).

Is there need re-tag v0.2.1? Or release a new tag to packing these changes?