### PR TITLE
fix(minirest): format_msg/1 returns tuple

### DIFF
--- a/src/minirest.appup.src
+++ b/src/minirest.appup.src
@@ -1,6 +1,10 @@
 %%-*-: erlang -*-
-{"0.3.5",
+{"0.3.6",
  [
+  {<<"0.3.5">>,
+    [ {load_module, minirest, brutal_purge, soft_purge, []}
+    ]
+  },
   {<<"0.3.[0-4]">>,
     [ {load_module, minirest, brutal_purge, soft_purge, []},
       {load_module, minirest_handler, brutal_purge, soft_purge, []}
@@ -9,6 +13,10 @@
   {<<".*">>, []}
  ],
  [
+  {<<"0.3.5">>,
+    [ {load_module, minirest, brutal_purge, soft_purge, []}
+    ]
+  },
   {<<"0.3.[0-4]">>,
     [ {load_module, minirest, brutal_purge, soft_purge, []},
       {load_module, minirest_handler, brutal_purge, soft_purge, []}

--- a/src/minirest.erl
+++ b/src/minirest.erl
@@ -207,10 +207,10 @@ to_map(M) when is_map(M) ->
     maps:map(fun(_, V) -> to_map(V) end, M);
 to_map(T) -> T.
 
+format_msg(Message) when is_binary(Message) ->
+    Message;
 format_msg(Message) ->
-    try unicode:characters_to_binary(Message)
-    catch error : badarg -> iolist_to_binary(io_lib:format("~0p", [Message]))
-    end.
+    iolist_to_binary(io_lib:format("~0p", [Message])).
 
 %%====================================================================
 %% EUnits


### PR DESCRIPTION
(<0.2128.0>) call minirest:format_msg(<<"Bad Arguments: {lex_error,{1,sql_lex,{illegal,\"Â\"}}}">>) ({minirest,
                                                                                                      return,
                                                                                                      1})
2021-06-09T17:15:06.064070+08:00 [error] Minirest(Handler): Encode #{code => 400,message => {error,<<"Bad Arguments: {lex_error,{1,sql_lex,{illegal,\"">>,<<"Â\"}}}">>}} failed with {invalid_ejson,{error,<<"Bad Arguments: {lex_error,{1,sql_lex,{illegal,\"">>,<<"Â\"}}}">>}}
(<0.2128.0>) returned from minirest:format_msg/1 -> {error,
                                                     <<"Bad Arguments: {lex_error,{1,sql_lex,{illegal,\"">>,
                                                     <<"Â\"}}}">>}