### PR TITLE
fix: api spec desc json encode & response headers replace default hea…

### DIFF
--- a/src/minirest_handler.erl
+++ b/src/minirest_handler.erl
@@ -131,7 +131,7 @@ reply({StatusCode, Body0}, Req) ->
 reply({StatusCode, Headers, Body0}, Req) ->
     case minirest_body:encode(Body0) of
         {ok, Headers1, Body} ->
-            cowboy_req:reply(StatusCode, maps:merge(Headers, Headers1), Body, Req);
+            cowboy_req:reply(StatusCode, maps:merge(Headers1, Headers), Body, Req);
         {response, Response} ->
             reply(Response, Req)
     end;


### PR DESCRIPTION
fix: api spec desc json encode & response headers replace default headers

```erlang
jsx:encode(#{description => "Description"}) = <<"{\"description\":[68,101,115,99,114,105,112,116,105,111,110]}">>
```
all description will be binary