### PR TITLE
fix: function_clause when bind listener port failed

### DIFF
--- a/src/minirest.erl
+++ b/src/minirest.erl
@@ -88,11 +88,13 @@ log_start_result({error, no_cert = Reason}, Log) ->
     ?LOG(error, Log#{msg => ?FAILED_MSG, description => "no_certificate_provided;", reason => Reason});
 %% copy from ranch.erl line:162
 log_start_result({error, {{shutdown, {failed_to_start_child, ranch_acceptors_sup,
-    {listen_error, _, Reason}}}, _}}, Log0) ->
+    Reason}}, _}}, Log0) ->
     Log = Log0#{msg => ?FAILED_MSG, reason => Reason},
     case Reason of
-        eaddrnotavail -> ?LOG(error, Log#{description => "cannot_assign_requested_address"});
-        ebusy -> ?LOG(error, Log#{description => "file_busy"});
+        {listen_error, _, eaddrnotavail} ->
+            ?LOG(error, Log#{description => "cannot_assign_requested_address"});
+        {listen_error, _, ebusy} ->
+            ?LOG(error, Log#{description => "file_busy"});
         _ -> ?LOG(error, Log)
     end.
 


### PR DESCRIPTION
2022-04-27T15:37:39.214963+08:00 [error] crasher: initial call: application_master:init/4, pid: <0.2169.0>, registered_name: [], exit: {{bad_return,{{emqx_dashboard_app,start,[normal,[]]},{'EXIT',{function_clause,[{minirest,log_start_result,[{error,{{shutdown,{failed_to_start_child,ranch_acceptors_sup,badarg}},{child,undefined,{ranch_listener_sup,'dashboard:https:18084'},{ranch_listener_sup,start_link,['dashboard:https:18084',ranch_ssl,#{connection_type => supervisor,max_connections => 512,num_acceptors => 4,socket_opts => [{next_protocols_advertised,[<<"h2">>,<<"http/1.1">>]},{alpn_preferred_protocols,[<<"h2">>,<<"http/1.1">>]},{versions,['tlsv1.3','tlsv1.2','tlsv1.1',tlsv1]},{verify,verify_none},{user_lookup_fun,{fun emqx_tls_psk:loo