### PR TITLE
feat: raise error for bad description

### DIFF
--- a/src/minirest_trails.erl
+++ b/src/minirest_trails.erl
@@ -147,7 +147,7 @@ generate_api_(Default, {Path, MetaData, Function, Options}) ->
 %% otherwise, raise minirest_description_not_format error.
 %% for example: can't find description in i18n file.
 decs_str_to_binary(#{description := Desc}) when is_tuple(Desc) ->
-    erlang:error({minirest_description_not_format, Desc});
+    erlang:error({minirest_description_not_formatted, Desc});
 decs_str_to_binary(Data = #{description := Desc}) when is_list(Desc) ->
     decs_str_to_binary(Data#{description => list_to_binary(Desc)});
 decs_str_to_binary(Data) when is_map(Data) ->

--- a/src/minirest_trails.erl
+++ b/src/minirest_trails.erl
@@ -143,6 +143,11 @@ generate_api_(Default, {Path, MetaData, Function, Options}) ->
         end,
     {Path, maps:fold(MergeDefFun, #{}, MetaData), Function, Options}.
 
+%% description must be a string(list or binary)
+%% otherwise, raise minirest_description_not_format error.
+%% for example: can't find description in i18n file.
+decs_str_to_binary(#{description := Desc}) when is_tuple(Desc) ->
+    erlang:error({minirest_description_not_format, Desc});
 decs_str_to_binary(Data = #{description := Desc}) when is_list(Desc) ->
     decs_str_to_binary(Data#{description => list_to_binary(Desc)});
 decs_str_to_binary(Data) when is_map(Data) ->


### PR DESCRIPTION
Sometimes we forget to set desc in the i18n file, which gives us a very long error and makes it difficult to find the missing desc. Now it will be easier to find it when we proactively raise it.
Before:

```
2023-05-22T05:58:48.755799+00:00 [error] crasher: initial call: cowboy_stream_h:request_process/3, pid: <0.2677.4>, registered_name: [], error: {badarith,[{erlang,'*',[desc,1000000],[{error_info,#{module => erl_erts_errors}}]},
{calendar,now_to_datetime,1,[{file,"calendar.erl"},{line,329}]},{jsx_parser,value,4,[{file,"jsx_parser.erl"},{line,113}]},
{cowboy_swagger_json_handler,handle_get,2,[{file,"cowboy_swagger_json_handler.erl"},{line,52}]},{cowboy_rest,call,3,
[{file,"cowboy_rest.erl"},{line,1576}]},{cowboy_rest,set_resp_body,2,[{file,"cowboy_rest.erl"},{line,1466}]},
{cowboy_rest,upgrade,4,[{file,"cowboy_rest.erl"},{line,288}]},{cowboy_stream_h,execute,3,[{file,"cowboy_stream_h.erl"},
{line,318}]},{cowboy_stream_h,request_process,3,[{file,"cowboy_stream_h.erl"},{line,302}]},{proc_lib,init_p_do_apply,3,
[{file,"proc_lib.erl"},{line,226}]}]}, ancestors: [<0.2671.4>,<0.3098.0>,<0.3097.0>,ranch_sup,<0.2607.0>], 
message_queue_len: 0, messages: [], links: [<0.2671.4>], dictionary: [], trap_exit: false, status: running, heap_size: 
196650, stack_size: 29, reductions: 6189703; neighbours:

2023-05-22T05:58:48.756315+00:00 [error] Ranch listener 'http:dashboard', connection process <0.2671.4>, stream 2 
had its request process <0.2677.4> exit with reason badarith and stacktrace [{erlang,'*',[desc,1000000],[{error_info,#
{module => erl_erts_errors}}]},{calendar,now_to_datetime,1,[{file,"calendar.erl"},{line,329}]},{jsx_parser,value,4,
[{file,"jsx_parser.erl"},{line,113}]},{cowboy_swagger_json_handler,handle_get,2,
[{file,"cowboy_swagger_json_handler.erl"},{line,52}]},{cowboy_rest,call,3,[{file,"cowboy_rest.erl"},{line,1576}]},
{cowboy_rest,set_resp_body,2,[{file,"cowboy_rest.erl"},{line,1466}]},{cowboy_rest,upgrade,4,[{file,"cowboy_rest.erl"},
{line,288}]},{cowboy_stream_h,execute,3,[{file,"cowboy_stream_h.erl"},{line,318}]},{cowboy_stream_h,request_process,3,
[{file,"cowboy_stream_h.erl"},{line,302}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]

```
After:
```
2023-05-22T22:14:26.742633+08:00 [error] Error in process <0.3151.0> on node 'emqx@127.0.0.1' with exit value:,
{{minirest_trails_api_spec_error,{minirest_description_not_format,{desc,emqx_ft_api,"file_list_transfer"}}}
[{minirest_trails,decs_str_to_binary,1,[{file,"minirest_trails.erl"},{line,150}]},{minirest_trails,'-generate_api_/2-fun-0-',4
[{file,"minirest_trails.erl"},{line,141}]},{maps,fold_1,3,[{file,"maps.erl"},{line,410}]},{minirest_trails,generate_api_,2
[{file,"minirest_trails.erl"},{line,144}]},{minirest_trails,'-api_spec/2-lc$^0/1-0-',2,[{file,"minirest_trails.erl"},{line,120}]}
{minirest_trails,api_spec,2,[{file,"minirest_trails.erl"},{line,120}]},{minirest_util,'-pmap_exec/4-fun-0-',3
[{file,"minirest_util.erl"},{line,31}]}]

```