### PR TITLE
feat: allow more flexible error responses

### DIFF
--- a/test/minirest_handler_SUITE.erl
+++ b/test/minirest_handler_SUITE.erl
@@ -26,7 +26,8 @@
 all() ->
     [
         t_lazy_body,
-        t_binary_body
+        t_binary_body,
+        t_flex_error
     ].
 
 init_per_suite(Config) ->
@@ -61,8 +62,12 @@ t_binary_body(_Config) ->
        {ok, {{_Version, 200, _Status}, _Headers, "alldataatonce"}},
        httpc:request(address() ++ "/binary_body")).
 
+t_flex_error(_Config) ->
+    {ok, {{_Version, 400, _Status}, _Headers, Body}} =
+       httpc:request(address() ++ "/flex_error"),
+    ?assertMatch(
+       #{<<"code">> := _, <<"message">> := _, <<"hint">> := _},
+       jsx:decode(iolist_to_binary(Body), [return_maps])).
+
 address() ->
     "http://localhost:" ++ integer_to_list(?PORT).
-
-
-

--- a/test/minirest_test_handler.erl
+++ b/test/minirest_test_handler.erl
@@ -20,12 +20,14 @@
 -export([api_spec/0]).
 
 -export([lazy_body/2,
-         binary_body/2]).
+         binary_body/2,
+         flex_error/2]).
 
 api_spec() ->
   {
     [lazy_body(),
-     binary_body()],
+     binary_body(),
+     flex_error()],
     []
   }.
 
@@ -55,6 +57,19 @@ binary_body() ->
                 },
   {"/binary_body", MetaData, binary_body}.
 
+flex_error() ->
+  MetaData = #{
+    get => #{
+      description => "binary body",
+      responses => #{
+      <<"400">> => #{
+          content => #{
+            'application/json' => #{
+                  schema => #{
+                      type => string}}}}}}
+    },
+  {"/flex_error", MetaData, flex_error}.
+
 lazy_body(get, _) ->
     BodyQH = qlc:table(fun() -> [<<"first">>, <<"second">>] end, []),
     {200, #{<<"content-type">> => <<"test/plain">>}, BodyQH}.
@@ -63,3 +78,5 @@ binary_body(get, _) ->
     Body = <<"alldataatonce">>,
     {200, #{<<"content-type">> => <<"test/plain">>}, Body}.
 
+flex_error(get, _) ->
+    {400, #{message => <<"boom">>, code => 'BAD_REQUEST', hint => <<"something went wrong">>}}.


### PR DESCRIPTION
This allows `minirest` to return keys in the root JSON document other than `message` and `code`.

e.g.:

```json
{
  "code": "BAD_REQUEST",
  "message": "boom",
  "hint": "something is wrong"
}
```