### PR TITLE
feat: collect multiple Qs paramaters to list

### DIFF
--- a/src/minirest_handler.erl
+++ b/src/minirest_handler.erl
@@ -99,11 +99,26 @@ do_authorize(_Request, _Handler) ->
 do_parse_params(Request) ->
     Params = #{
         bindings => cowboy_req:bindings(Request),
-        query_string => maps:from_list(cowboy_req:parse_qs(Request)),
+        query_string => parse_qs(Request),
         headers => cowboy_req:headers(Request),
         body => #{}
     },
     do_read_body(Request, Params).
+
+parse_qs(Request) ->
+    lists:foldl(
+      fun({K, V}, MapAcc) ->
+              maps:update_with(
+                K,
+                fun([_|_] = OldV) -> [V | OldV];
+                   (OldV) -> [V, OldV]
+                end,
+                V,
+                MapAcc)
+      end,
+      #{},
+      cowboy_req:parse_qs(Request)
+     ).
 
 do_read_body(Request, Params) ->
     case cowboy_req:has_body(Request) of

--- a/test/minirest_handler_SUITE.erl
+++ b/test/minirest_handler_SUITE.erl
@@ -27,7 +27,8 @@ all() ->
     [
         t_lazy_body,
         t_binary_body,
-        t_flex_error
+        t_flex_error,
+        t_qs_params
     ].
 
 init_per_suite(Config) ->
@@ -68,6 +69,12 @@ t_flex_error(_Config) ->
     ?assertMatch(
        #{<<"code">> := _, <<"message">> := _, <<"hint">> := _},
        jsx:decode(iolist_to_binary(Body), [return_maps])).
+
+t_qs_params(_Config) ->
+    ?assertMatch(
+       {ok, {{_Version, 200, _Status}, _Headers, "OK"}},
+       httpc:request(address() ++ "/qs_params?single=foo&array=foo&array=bar")
+      ).
 
 address() ->
     "http://localhost:" ++ integer_to_list(?PORT).

--- a/test/minirest_test_handler.erl
+++ b/test/minirest_test_handler.erl
@@ -21,13 +21,15 @@
 
 -export([lazy_body/2,
          binary_body/2,
-         flex_error/2]).
+         flex_error/2,
+         qs_params/2]).
 
 api_spec() ->
   {
     [lazy_body(),
      binary_body(),
-     flex_error()],
+     flex_error(),
+     qs_params()],
     []
   }.
 
@@ -57,6 +59,20 @@ binary_body() ->
                 },
   {"/binary_body", MetaData, binary_body}.
 
+
+qs_params() ->
+    MetaData = #{
+        get => #{
+            description => "parse QS params",
+            responses => #{
+            <<"200">> => #{
+                content => #{
+                  'text/plain' => #{
+                        schema => #{
+                            type => string}}}}}}
+                },
+  {"/qs_params", MetaData, qs_params}.
+
 flex_error() ->
   MetaData = #{
     get => #{
@@ -77,6 +93,10 @@ lazy_body(get, _) ->
 binary_body(get, _) ->
     Body = <<"alldataatonce">>,
     {200, #{<<"content-type">> => <<"test/plain">>}, Body}.
+
+qs_params(get, #{query_string := Qs}) ->
+    #{<<"single">> := <<"foo">>, <<"array">> := [<<"bar">>, <<"foo">>]} = Qs,
+    {200,  #{<<"content-type">> => <<"test/plain">>}, <<"OK">>}.
 
 flex_error(get, _) ->
     {400, #{message => <<"boom">>, code => 'BAD_REQUEST', hint => <<"something went wrong">>}}.


### PR DESCRIPTION
The goal is to support query strings like: `clientid=a&clientid=b`.
However, we probably need to apply it conditionally since it's not backward-compatible: previous implementation was silently dropping all besides the last value, while the new one will collect all values to the list.