### PR TITLE
feat: make the metadata of an endpoint be more flexible

### DIFF
--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -7,22 +7,22 @@ jobs:
         runs-on: ubuntu-latest
       
         container:
-            image: emqx/build-env:erl23.2.7.2-emqx-2-ubuntu20.04
+            image: ghcr.io/emqx/emqx-builder/5.3-13:1.15.7-26.2.5.2-1-ubuntu22.04
             
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v4
             - name: run test cases
               run: |
                 make xref
                 make eunit  
                 make ct
                 make cover
-            - uses: actions/upload-artifact@v1
+            - uses: actions/upload-artifact@v4
               if: always()
               with:
                 name: logs
                 path: _build/test/logs
-            - uses: actions/upload-artifact@v1
+            - uses: actions/upload-artifact@v4
               with:
                 name: cover
                 path: _build/test/cover


### PR DESCRIPTION
Fixes EMQX-13225

In previous versions, the metadata was statically derived from the `authorize` method, but some endpoints (login, external callback of SSO) may not have an `authorize` method, or it may be an interactive endpoint whose metadata cannot be determined in one step.

Here, the metadata is moved from the function return to the process dictionary, so that the metadata in the endpoint can be updated.