### PR TITLE
feat: allows custom metadata at the endpoint level

### DIFF
--- a/include/minirest.hrl
+++ b/include/minirest.hrl
@@ -67,7 +67,7 @@
     function        :: atom(),
     filter          :: fun(),
     authorization   :: {Module :: atom(), Function :: atom()} | undefined,
-    log             :: fun() | undefined,
+    log_meta        :: map(),
     error_codes     :: list(error_code())
 }).
 

--- a/src/minirest_trails.erl
+++ b/src/minirest_trails.erl
@@ -73,13 +73,14 @@ trails_schemas(BasePath, Authorization, Log, Module, {Path, Metadata, Function, 
                 function      = Function,
                 authorization = maps:get(security, MethodDef, []) =/= [] andalso Authorization,
                 filter        = maps:get(filter, Options, undefined),
-                log           = Log,
+                log_meta      = maps:get(log_meta, MethodDef, #{}),
                 error_codes   = ErrorCodes
                 },
             minirest_info_api:add_codes(ErrorCodes),
             maps:put(binary_method(Method), HandlerState, HandlerStates)
         end,
-    HandlerStates = maps:fold(Fun, #{}, Metadata),
+    MethodStates = maps:fold(Fun, #{}, Metadata),
+    HandlerStates = #{log => Log, methods => MethodStates},
     CompletePath  = append_base_path(BasePath, Path),
     trails:trail(CompletePath, ?HANDLER, HandlerStates, Metadata).
 


### PR DESCRIPTION
Also fixed an issue where nothing would be logged when the method was not allowed