### PR TITLE
fix: adjust the structure of `handler` and `handler state`

### DIFF
--- a/include/minirest.hrl
+++ b/include/minirest.hrl
@@ -62,7 +62,6 @@
 
 -record(handler, {
     method          :: http_method(),
-    path            :: string(),
     module          :: atom(),
     function        :: atom(),
     filter          :: fun(),
@@ -70,6 +69,14 @@
     log_meta        :: map(),
     error_codes     :: list(error_code())
 }).
+
+-type handler() :: #handler{}.
+
+-type handler_state() :: #{
+    path := path(),
+    log := {module(), atom(), InitMeta :: map()} | undefined,
+    methods := #{http_method() => handler()}
+}.
 
 -define(MFA, {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY}).
 -define(LOG(Level, Data), logger:log(Level, Data, #{mfa => ?MFA, line => ?LINE})).


### PR DESCRIPTION
Each `path` has a unique corresponding route and `minirest_handler`, all methods in this handler share this `path`,  here lift this data from the method handler to handle the `not allowed` clause.