### PR TITLE
perf: use batch methods for registering swagger schemas

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 {deps, [
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.0"}}},
-    {cowboy_swagger, {git, "https://github.com/inaka/cowboy_swagger", {tag, "2.7.0"}}}
+    {cowboy_swagger, {git, "https://github.com/emqx/cowboy_swagger", {tag, "2.7.0-emqx1"}}}
 ]}.
 
 {plugins, [

--- a/src/minirest.erl
+++ b/src/minirest.erl
@@ -56,28 +56,38 @@ update_dispatch(Name) ->
     [Name, _Transport, _SocketOpts, _Protocol, StartArgs] =
         ranch_server:get_listener_start_args(Name),
     #{env := #{options := Options}} = StartArgs,
-    #{
-        dispatch := NewDispatch,
-        schemas := Schemas,
-        trials := Trails
-    } = generate_dispatch(Options),
+    Dispatch =
+        #{
+            dispatch := NewDispatch
+        } = generate_dispatch(Options),
     persistent_term:put(Name, NewDispatch),
     SwaggerSupport = maps:get(swagger_support, Options, true),
-    SwaggerSupport andalso set_swagger_global_spec(Options),
-    SwaggerSupport andalso trails:store(Name, Trails),
-    SwaggerSupport andalso [cowboy_swagger:add_definition(Schema) || Schema <- Schemas],
+    SwaggerSupport andalso setup_swagger(Name, Options, Dispatch),
     Protocol = #{env := Env} = ranch:get_protocol_options(Name),
     ranch:set_protocol_options(Name, Protocol#{env => maps:remove(options, Env)}),
     ok.
 
+setup_swagger(Name, Options, Dispatch) ->
+    #{
+        schemas := Schemas,
+        trials := Trails,
+        error_codes := ErrorCodes
+    } = Dispatch,
+    set_swagger_global_spec(Options),
+    trails:store(Name, Trails),
+    cowboy_swagger:add_definitions(Schemas),
+    minirest_info_api:add_codes(ErrorCodes),
+    ok.
+
 generate_dispatch(Options) ->
     [{_Host0, _CowField0, Routers}] = merge_dispatch([], Options),
-    {Trails, Schemas} = minirest_trails:trails_schemas(Options),
+    {Trails, Schemas, ErrorCodes} = minirest_trails:trails_schemas(Options),
     [{Host, CowField, RestRouters}] = trails:single_host_compile(Trails),
     #{
         dispatch => [{Host, CowField, RestRouters ++ Routers}],
         schemas => Schemas,
-        trials => Trails
+        trials => Trails,
+        error_codes => ErrorCodes
     }.
 
 stop(Name) ->

--- a/src/minirest_info_api.erl
+++ b/src/minirest_info_api.erl
@@ -90,8 +90,13 @@ set_codes(NewCodes) ->
     end.
 
 codes() ->
-    case application:get_env(cowboy_swagger, global_spec, #{}) of
-        #{components := #{schemas := #{minirest_api_error_codes := #{enum := Codes}}}} ->
+    GlobalSpec = cowboy_swagger:get_global_spec(),
+    case GlobalSpec of
+        #{
+            <<"components">> := #{
+                <<"schemas">> := #{<<"minirest_api_error_codes">> := #{<<"enum">> := Codes}}
+            }
+        } ->
             Codes;
         _ ->
             []

--- a/test/minirest_handler_SUITE.erl
+++ b/test/minirest_handler_SUITE.erl
@@ -39,7 +39,7 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
-    minirest:stop(?SERVER_NAME).
+    ok.
 
 init_per_testcase(t_handler_meta_in_auth, Config) ->
     ok = start_minirest(
@@ -121,7 +121,7 @@ start_minirest(MinirestOptions0) ->
     MinirestOptions = maps:merge(
         #{
             base_path => "",
-            modules => [?HANDLER_MODULE],
+            modules => [?HANDLER_MODULE, minirest_info_api],
             authorization => {?HANDLER_MODULE, authorize1},
             dispatch => [{"/[...]", ?HANDLER_MODULE, []}],
             protocol => http,

--- a/test/minirest_info_api_SUITE.erl
+++ b/test/minirest_info_api_SUITE.erl
@@ -1,0 +1,50 @@
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(minirest_info_api_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("stdlib/include/assert.hrl").
+
+all() ->
+    [
+        t_codes
+    ].
+
+init_per_suite(Config) ->
+    application:ensure_all_started(minirest),
+    minirest_handler_SUITE:start_minirest(),
+    Config.
+
+end_per_suite(_Config) ->
+    minirest_handler_SUITE:stop_minirest().
+
+%%--------------------------------------------------------------------
+%% Test cases
+%%--------------------------------------------------------------------
+
+t_codes(_Config) ->
+    minirest_info_api:add_codes(['BAD_REQUEST', 'NOT_FOUND']),
+    ?assertMatch(
+        [<<"BAD_REQUEST">>, <<"NOT_FOUND">>],
+        minirest_info_api:codes()
+    ),
+    {ok, {{_Version, 200, _ReasonPhrase}, _Headers, Body}} =
+        httpc:request(minirest_handler_SUITE:address() ++ "/info/error/codes"),
+    ?assertEqual(
+        #{<<"codes">> => [<<"BAD_REQUEST">>, <<"NOT_FOUND">>]},
+        jsx:decode(iolist_to_binary(Body), [return_maps])
+    ).


### PR DESCRIPTION
**Update `cowboy_swagger` repo before merge** 

Generating emqx (5.10) dispatch:
`minirest-1.4.6`,  `cowboy_swagger-2.5.0` — 8294ms
`minirest-1.4.6`,  `cowboy_swagger-2.7.0` — 32234ms. `cowboy_swagger-2.7.0` made things much worse with even more aggressive json normalization in many places.
`minirest` after this PR,  `cowboy_swagger` with https://github.com/emqx/cowboy_swagger/pull/6  — 180ms