### PR TITLE
fix: function clause error when already started

### DIFF
--- a/src/minirest.erl
+++ b/src/minirest.erl
@@ -136,6 +136,8 @@ log_start_result({error, no_cert = Reason}, Log) ->
     ?LOG(error, Log#{
         msg => ?FAILED_MSG, description => "no_certificate_provided;", reason => Reason
     });
+log_start_result({error, {already_started, Pid}}, Log) ->
+    ?LOG(info, Log#{msg => "listener_already_started", pid => Pid});
 %% copy from ranch.erl line:162
 log_start_result(
     {error, {{shutdown, {failed_to_start_child, ranch_acceptors_sup, Reason}}, _}}, Log0
@@ -148,7 +150,9 @@ log_start_result(
             ?LOG(error, Log#{description => "file_busy"});
         _ ->
             ?LOG(error, Log)
-    end.
+    end;
+log_start_result({error, Reason}, Log) ->
+    ?LOG(error, Log#{msg => "error_starting_listener", reason => Reason}).
 
 get_port(L) when is_list(L) -> proplists:get_value(port, L);
 get_port(#{port := Port}) -> Port;


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/15634307273/job/44046132360?pr=15377#step:5:465

```
%%% emqx_dashboard_https_SUITE ==> t_verify_cacertfile: FAILED
%%% emqx_dashboard_https_SUITE ==> {function_clause,
    [{minirest,log_start_result,
         [{error,{already_started,<0.262357.0>}},
          #{name => 'https:dashboard',port => 18084}],
         [{file,"/__w/emqx/emqx/_build/default/lib/minirest/src/minirest.erl"},
          {line,129}]},
     {minirest,start_listener_,4,
         [{file,"/__w/emqx/emqx/_build/default/lib/minirest/src/minirest.erl"},
          {line,124}]},
     {emqx_dashboard,'-start_listeners/1-fun-0-',3,
         [{file,"/__w/emqx/emqx/apps/emqx_dashboard/src/emqx_dashboard.erl"},
          {line,61}]},
     {lists,foldl,3,[{file,"lists.erl"},{line,2146}]},
     {emqx_dashboard,start_listeners,1,
         [{file,"/__w/emqx/emqx/apps/emqx_dashboard/src/emqx_dashboard.erl"},
          {line,52}]},
     {emqx_dashboard_https_SUITE,t_verify_cacertfile,1,
         [{file,
              "/__w/emqx/emqx/apps/emqx_dashboard/test/emqx_dashboard_https_SUITE.erl"},
          {line,242}]},
```