### PR TITLE
feat: pass route path to authorize callback via HandlerInfo

### DIFF
--- a/src/minirest_handler.erl
+++ b/src/minirest_handler.erl
@@ -62,7 +62,7 @@ handle(Request, #{path := Path, methods := Methods} = State) ->
             };
         {ok, Handler = #handler{log_meta = LogMeta, method = MethodAtom}} ->
             init_log_meta(LogMeta#{operation_id => OperationId, method => MethodAtom}),
-            case do_authorize(Request, Handler) of
+            case do_authorize(Request, Path, Handler) of
                 {ok, AuthMeta} ->
                     update_log_meta(AuthMeta),
                     case do_parse_params(Request, AuthMeta) of
@@ -112,17 +112,17 @@ trans_allow([], Res) -> Res;
 trans_allow([Method], Res) -> <<Res/binary, Method/binary>>;
 trans_allow([Method | Allow], Res) -> trans_allow(Allow, <<Res/binary, Method/binary, ", ">>).
 
-do_authorize(Request, #handler{
+do_authorize(Request, Path, #handler{
     authorization = {M, F}, method = Method, module = Mod, function = Fun
 }) ->
-    HandlerInfo = #{method => Method, module => Mod, function => Fun},
+    HandlerInfo = #{method => Method, module => Mod, function => Fun, path => Path},
     case erlang:function_exported(M, F, 2) of
         true ->
             erlang:apply(M, F, [Request, HandlerInfo]);
         false ->
             erlang:apply(M, F, [Request])
     end;
-do_authorize(_Request, _Handler) ->
+do_authorize(_Request, _Path, _Handler) ->
     {ok, #{}}.
 
 do_parse_params(Request, AuthMeta) ->

--- a/test/minirest_handler_SUITE.erl
+++ b/test/minirest_handler_SUITE.erl
@@ -32,6 +32,7 @@ all() ->
         t_auth_meta_in_filter,
         t_auth_meta_in_handler,
         t_handler_meta_in_auth,
+        t_route_path_in_auth,
         t_post_large_body
     ].
 
@@ -46,6 +47,11 @@ end_per_suite(_Config) ->
 init_per_testcase(t_handler_meta_in_auth, Config) ->
     ok = start_minirest(
         #{authorization => {?HANDLER_MODULE, authorize2}}
+    ),
+    Config;
+init_per_testcase(t_route_path_in_auth, Config) ->
+    ok = start_minirest(
+        #{authorization => {?HANDLER_MODULE, authorize_path}}
     ),
     Config;
 init_per_testcase(_Case, Config) ->
@@ -105,6 +111,19 @@ t_handler_meta_in_auth(_Config) ->
             "hello from minirest_test_handler:handler_meta_in_auth"
         }},
         httpc:request(address() ++ "/handler_meta_in_auth")
+    ).
+
+%% Verify that the authorize callback receives the route template path
+%% (e.g. "/route_path_in_auth/:id") rather than the actual request path
+%% (e.g. "/route_path_in_auth/42").
+t_route_path_in_auth(_Config) ->
+    ?assertMatch(
+        {ok, {
+            {_Version, 200, _Status},
+            _Headers,
+            "/route_path_in_auth/:id"
+        }},
+        httpc:request(address() ++ "/route_path_in_auth/42")
     ).
 
 t_post_large_body(_Config) ->

--- a/test/minirest_test_handler.erl
+++ b/test/minirest_test_handler.erl
@@ -22,6 +22,7 @@
 -export([
     authorize1/1,
     authorize2/2,
+    authorize_path/2,
     lazy_body/2,
     binary_body/2,
     flex_error/2,
@@ -29,6 +30,7 @@
     auth_meta_in_filter/2,
     auth_meta_in_handler/2,
     handler_meta_in_auth/2,
+    route_path_in_auth/2,
     post_large_body/2
 ]).
 
@@ -42,6 +44,7 @@ api_spec() ->
             auth_meta_in_filter(),
             auth_meta_in_handler(),
             handler_meta_in_auth(),
+            route_path_in_auth(),
             post_large_body()
         ],
         []
@@ -126,6 +129,16 @@ handler_meta_in_auth() ->
     },
     {"/handler_meta_in_auth", MetaData, handler_meta_in_auth}.
 
+route_path_in_auth() ->
+    MetaData = #{
+        get => #{
+            description => "route path in auth",
+            responses => text_plain_200_response(),
+            security => [#{application => []}]
+        }
+    },
+    {"/route_path_in_auth/:id", MetaData, route_path_in_auth}.
+
 post_large_body() ->
     MetaData = #{
         post => #{
@@ -148,6 +161,9 @@ authorize2(_Req, #{module := Module, function := Fun}) ->
         message =>
             <<"hello from ", (atom_to_binary(Module))/binary, ":", (atom_to_binary(Fun))/binary>>
     }}.
+
+authorize_path(_Req, #{path := Path}) ->
+    {ok, #{route_path => list_to_binary(Path)}}.
 
 lazy_body(get, _) ->
     BodyQH = qlc:table(fun() -> [<<"first">>, <<"second">>] end, []),
@@ -172,6 +188,9 @@ auth_meta_in_handler(get, #{auth_meta := #{message := Message}}) ->
 
 handler_meta_in_auth(get, #{auth_meta := #{message := Message}}) ->
     {200, #{<<"content-type">> => <<"test/plain">>}, Message}.
+
+route_path_in_auth(get, #{auth_meta := #{route_path := RoutePath}}) ->
+    {200, #{<<"content-type">> => <<"test/plain">>}, RoutePath}.
 
 post_large_body(post, #{body := _Body}) ->
     {200, #{<<"content-type">> => <<"test/plain">>}, <<"OK">>}.


### PR DESCRIPTION
## Summary

Pass the route template path (e.g. `"/clients/:clientid"`) to the authorize callback via the `HandlerInfo` map, enabling authorization logic to use the **same path** that was used for handler dispatch — rather than parsing `cowboy_req:path(Req)` independently.

## Motivation

In [emqx/emqx#16942](https://github.com/emqx/emqx/pull/16942) (API Key scope-based authorization), the authorize callback needs to know which route was matched in order to check permissions. Previously, the only option was to re-parse the raw request path from `cowboy_req:path(Req)` and match it against route patterns — effectively building a parallel path resolution system. This is fragile and security-sensitive (see [review comment](https://github.com/emqx/emqx/pull/16942#discussion_r2976809545)).

By passing the route `Path` from the dispatch state directly, we eliminate the dual-resolution concern entirely.

## Changes

**`src/minirest_handler.erl`** — 1 file, 4 lines changed:

1. `do_authorize/2` → `do_authorize/3`: accepts the `Path` parameter from `handle/2`'s dispatch state
2. `HandlerInfo` map: adds `path => Path` field (route template string, e.g. `"/clients/:clientid"`)
3. No record changes — `#handler{}` is untouched to preserve hot-upgrade compatibility

## Backward Compatibility

- The `authorize` callback with arity 2 (`M:F(Request, HandlerInfo)`) receives the extra `path` key in `HandlerInfo` — existing callbacks that pattern-match on `HandlerInfo` without `path` are unaffected
- The arity-1 fallback (`M:F(Request)`) is unchanged
- No public API changes