### PR TITLE
fix: avoid attaching botched content-length header

### DIFF
--- a/src/body_encoder/minirest_binary_encoder.erl
+++ b/src/body_encoder/minirest_binary_encoder.erl
@@ -19,4 +19,4 @@
 -export([encode/1]).
 
 encode(Body) ->
-    {ok, maps:merge(?DEFAULT_RESPONSE_HEADERS, #{<<"content-length">> => erlang:size(Body)}), Body}.
+    {ok, #{}, Body}.


### PR DESCRIPTION
Before this commit, `#{<<"content-length">> => 0}` attached to response headers of body-less reponses can cause literal NULL byte to appear in the response stream as part of this header.

This was possible because header-value was fed into a stream verbatim, and sub-256 integer is a valid piece of `iodata()`.

E.g. in `cow_http1`, as part of `cowboy_http:commands/3` -> `cow_http:response/3` -> `cow_http1:response/3` call chain:
```
headers(Headers) ->
    [[N, <<": ">>, V, <<"\r\n">>] || {N, V} <- Headers]
```
