### PR TITLE
chore: bump cowboy_swagger to 3.0.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 {deps, [
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.0"}}},
-    {cowboy_swagger, {git, "https://github.com/emqx/cowboy_swagger", {tag, "2.7.0-emqx2"}}}
+    {cowboy_swagger, {git, "https://github.com/emqx/cowboy_swagger", {tag, "3.0.0"}}}
 ]}.
 
 {profiles, [


### PR DESCRIPTION
The 3.0.0 release strips the bundled Swagger UI assets and the /api-docs trails so downstream releases (notably EMQX) can shed ~11 MB of static UI from the release tarball. The library API used by minirest itself (cowboy_swagger:add_definitions/1, cowboy_swagger:to_json/1, etc.) is unchanged.