### PR TITLE
fix(handler): preserve request order for repeated query-string params

### DIFF
--- a/src/minirest_handler.erl
+++ b/src/minirest_handler.erl
@@ -136,7 +136,8 @@ do_parse_params(Request, AuthMeta) ->
     do_read_body(Request, Params).
 
 parse_qs(Request) ->
-    lists:foldl(
+    %% foldr so repeated params accumulate in request order
+    lists:foldr(
         fun({K, V}, MapAcc) ->
             maps:update_with(
                 K,

--- a/test/minirest_handler_SUITE.erl
+++ b/test/minirest_handler_SUITE.erl
@@ -88,7 +88,7 @@ t_flex_error(_Config) ->
 t_qs_params(_Config) ->
     ?assertMatch(
         {ok, {{_Version, 200, _Status}, _Headers, "OK"}},
-        httpc:request(address() ++ "/qs_params?single=foo&array=foo&array=bar")
+        httpc:request(address() ++ "/qs_params?single=foo&array=foo&array=bar&array=baz")
     ).
 
 t_auth_meta_in_filter(_Config) ->

--- a/test/minirest_test_handler.erl
+++ b/test/minirest_test_handler.erl
@@ -174,7 +174,7 @@ binary_body(get, _) ->
     {200, #{<<"content-type">> => <<"test/plain">>}, Body}.
 
 qs_params(get, #{query_string := Qs}) ->
-    #{<<"single">> := <<"foo">>, <<"array">> := [<<"bar">>, <<"foo">>]} = Qs,
+    #{<<"single">> := <<"foo">>, <<"array">> := [<<"foo">>, <<"bar">>, <<"baz">>]} = Qs,
     {200, #{<<"content-type">> => <<"test/plain">>}, <<"OK">>}.
 
 flex_error(get, _) ->


### PR DESCRIPTION
## Root cause

`minirest_handler:parse_qs/1` folds over `cowboy_req:parse_qs/1` (which yields pairs in request order) with `lists:foldl` while **prepending** each repeated value, so multi-value query parameters reached handlers in reverse request order: `/qs_params?array=foo&array=bar` arrived as `[<<"bar">>, <<"foo">>]`.

## Fix

Fold with `lists:foldr` instead. The last occurrence is seen first (stored as the scalar), and each earlier occurrence prepends in front of it, yielding request order. Single-occurrence params are unchanged (still a bare scalar, not a list); valueless flags (`?foo` → `true`) are unchanged as well.

## Behavior change

This is an observable ordering change for any consumer of multi-value query params: they now arrive in request order instead of reversed. The reversed order was an undocumented fold accident, and no known consumer relies on it. Known consumers want request order — emqx/emqx#18267 promises "results in query-parameter order" for `GET /clients?clientid=a&clientid=b`, and the order-sensitive tests in emqx/emqx#18268 tripped over the reversal. The existing `t_qs_params` test asserted the reversed order; it is flipped and strengthened to three occurrences.

## Follow-ups (not in this PR)

- Tag the next minirest release and bump the pin in emqx.git (currently `1.4.12`).