### PR TITLE
feat(handler): send response cookies returned by a handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,23 @@ hello(Method, #{bindings := Bindins,
 
 ```
 
+## Set a response cookie
+
+Return the formatted cookie under the lower case `set-cookie` key of the
+response headers. Use `cow_cookie:setcookie/3` to build it. Pass a list of
+binaries to send several cookies, which minirest sends as one `set-cookie`
+header each.
+
+```erlang
+login(post, _Params) ->
+    Cookie = iolist_to_binary(
+        cow_cookie:setcookie(<<"session">>, Token, #{
+            path => <<"/api">>, http_only => true, secure => true, max_age => 3600
+        })
+    ),
+    {200, #{<<"set-cookie">> => Cookie}, #{}}.
+```
+
 ## Start your HTTP server
 
 ```erlang

--- a/src/minirest_handler.erl
+++ b/src/minirest_handler.erl
@@ -258,9 +258,13 @@ reply(BadReturn, Req, _Handler) ->
     {StatusCode,
         cowboy_req:reply(StatusCode, #{<<"content-type">> => <<"text/plain">>}, Body, Req)}.
 
-reply_with_body(StatusCode, Headers, Body, Req) when is_binary(Body) ->
+reply_with_body(StatusCode, Headers0, Body, Req0) ->
+    {Headers, Req} = take_resp_cookies(Headers0, Req0),
+    do_reply_with_body(StatusCode, Headers, Body, Req).
+
+do_reply_with_body(StatusCode, Headers, Body, Req) when is_binary(Body) ->
     cowboy_req:reply(StatusCode, Headers, Body, Req);
-reply_with_body(StatusCode, Headers, {qlc_handle, _} = BodyQH, Req0) ->
+do_reply_with_body(StatusCode, Headers, {qlc_handle, _} = BodyQH, Req0) ->
     Req1 = cowboy_req:stream_reply(StatusCode, Headers, Req0),
     qlc:fold(
         fun(Data, Req) ->
@@ -272,6 +276,47 @@ reply_with_body(StatusCode, Headers, {qlc_handle, _} = BodyQH, Req0) ->
     ),
     cowboy_req:stream_body(<<>>, fin, Req1),
     Req1.
+
+%% `set-cookie' is the one response header cowboy does not take from the
+%% headers map. A response may carry several of them, and a map holds one
+%% value per name, so cowboy keeps cookies in the request's `resp_cookies'
+%% field and fills the map key itself at reply time. Passing the header in
+%% exits with `response_error' on cowboy 2.10 and later, and clobbers any
+%% cookie already set on the request before that. Move it to where cowboy
+%% expects it instead.
+%%
+%% The value is one cookie as a binary, or several as a list of binaries,
+%% each already formatted by `cow_cookie:setcookie/3'. The header name must
+%% be lower case, as it must be for HTTP/2 anyway.
+take_resp_cookies(Headers, Req) ->
+    case maps:take(<<"set-cookie">>, Headers) of
+        error ->
+            {Headers, Req};
+        {Cookies, Headers1} ->
+            {Headers1, put_resp_cookies(Cookies, Req)}
+    end.
+
+put_resp_cookies(Cookie, Req) when is_binary(Cookie) ->
+    put_resp_cookies([Cookie], Req);
+put_resp_cookies(Cookies, Req) when is_list(Cookies) ->
+    RespCookies = maps:get(resp_cookies, Req, #{}),
+    Req#{resp_cookies => lists:foldl(fun put_resp_cookie/2, RespCookies, Cookies)};
+put_resp_cookies(Cookies, _Req) ->
+    error({invalid_set_cookie_header, Cookies}).
+
+%% Cowboy keys `resp_cookies' by cookie name, so that setting the same cookie
+%% twice replaces it instead of sending two headers the browser cannot
+%% reconcile. Key it the same way.
+put_resp_cookie(Cookie, Acc) when is_binary(Cookie) ->
+    Acc#{resp_cookie_name(Cookie) => Cookie};
+put_resp_cookie(Cookie, _Acc) ->
+    error({invalid_set_cookie_header, Cookie}).
+
+resp_cookie_name(Cookie) ->
+    case binary:split(Cookie, <<"=">>) of
+        [Name, _Value] -> Name;
+        [Name] -> Name
+    end.
 
 maybe_ignore_code_check(401, _Code) -> true;
 maybe_ignore_code_check(403, _Code) -> true;

--- a/test/minirest_handler_SUITE.erl
+++ b/test/minirest_handler_SUITE.erl
@@ -33,7 +33,9 @@ all() ->
         t_auth_meta_in_handler,
         t_handler_meta_in_auth,
         t_route_path_in_auth,
-        t_post_large_body
+        t_post_large_body,
+        t_set_cookie,
+        t_set_cookies
     ].
 
 init_per_suite(Config) ->
@@ -135,9 +137,35 @@ t_post_large_body(_Config) ->
     {ok, 200, _, Ref} = hackney:request(post, URL, Headers, Json100MB, []),
     ?assertEqual({ok, <<"OK">>}, hackney:body(Ref)).
 
+%% A handler that returns a `set-cookie' header gets it sent as a cookie,
+%% instead of cowboy rejecting the response.
+t_set_cookie(_Config) ->
+    {ok, 200, Headers, _Ref} = hackney:request(get, address() ++ "/set_cookie"),
+    %% The exact attribute list depends on the cowlib version, so assert on
+    %% the pair and the attributes the handler asked for.
+    [Cookie] = set_cookie_headers(Headers),
+    ?assertEqual(<<"one=1">>, cookie_pair(Cookie)),
+    ?assertNotEqual(nomatch, binary:match(Cookie, <<"Path=/api">>)),
+    ?assertNotEqual(nomatch, binary:match(Cookie, <<"HttpOnly">>)).
+
+%% Several cookies are sent as one `set-cookie' header each, which is the
+%% only correct encoding for them.
+t_set_cookies(_Config) ->
+    {ok, 200, Headers, _Ref} = hackney:request(get, address() ++ "/set_cookies"),
+    ?assertEqual(
+        [<<"one=1">>, <<"two=2">>],
+        lists:sort([cookie_pair(C) || C <- set_cookie_headers(Headers)])
+    ).
+
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
+
+set_cookie_headers(Headers) ->
+    [V || {K, V} <- Headers, string:lowercase(K) =:= <<"set-cookie">>].
+
+cookie_pair(Cookie) ->
+    hd(binary:split(Cookie, <<";">>)).
 
 start_minirest() ->
     start_minirest(#{}).

--- a/test/minirest_test_handler.erl
+++ b/test/minirest_test_handler.erl
@@ -31,7 +31,9 @@
     auth_meta_in_handler/2,
     handler_meta_in_auth/2,
     route_path_in_auth/2,
-    post_large_body/2
+    post_large_body/2,
+    set_cookie/2,
+    set_cookies/2
 ]).
 
 api_spec() ->
@@ -45,7 +47,9 @@ api_spec() ->
             auth_meta_in_handler(),
             handler_meta_in_auth(),
             route_path_in_auth(),
-            post_large_body()
+            post_large_body(),
+            set_cookie(),
+            set_cookies()
         ],
         []
     }.
@@ -149,6 +153,24 @@ post_large_body() ->
     },
     {"/post_large_body", MetaData, post_large_body}.
 
+set_cookie() ->
+    MetaData = #{
+        get => #{
+            description => "set one response cookie",
+            responses => text_plain_200_response()
+        }
+    },
+    {"/set_cookie", MetaData, set_cookie}.
+
+set_cookies() ->
+    MetaData = #{
+        get => #{
+            description => "set two response cookies",
+            responses => text_plain_200_response()
+        }
+    },
+    {"/set_cookies", MetaData, set_cookies}.
+
 %%--------------------------------------------------------------------
 %% Handlers
 %%--------------------------------------------------------------------
@@ -194,6 +216,21 @@ route_path_in_auth(get, #{auth_meta := #{route_path := RoutePath}}) ->
 
 post_large_body(post, #{body := _Body}) ->
     {200, #{<<"content-type">> => <<"test/plain">>}, <<"OK">>}.
+
+set_cookie(get, _) ->
+    Cookie = iolist_to_binary(
+        cow_cookie:setcookie(<<"one">>, <<"1">>, #{path => <<"/api">>, http_only => true})
+    ),
+    Headers = #{<<"content-type">> => <<"test/plain">>, <<"set-cookie">> => Cookie},
+    {200, Headers, <<"OK">>}.
+
+set_cookies(get, _) ->
+    Cookies = [
+        iolist_to_binary(cow_cookie:setcookie(<<"one">>, <<"1">>, #{})),
+        iolist_to_binary(cow_cookie:setcookie(<<"two">>, <<"2">>, #{}))
+    ],
+    Headers = #{<<"content-type">> => <<"test/plain">>, <<"set-cookie">> => Cookies},
+    {200, Headers, <<"OK">>}.
 
 %%--------------------------------------------------------------------
 %% Helpers


### PR DESCRIPTION
## Summary

A minirest handler cannot set a response cookie today. `reply_with_body/4` passes the
handler's header map straight to `cowboy_req:reply/4`, and cowboy does not accept
`set-cookie` there:

```erlang
%% cowboy_req.erl
reply(_, #{<<"set-cookie">> := _}, _, _) ->
    exit({response_error, invalid_header,
        'Response cookies must be set using cowboy_req:set_resp_cookie/3,4.'});
```

The reason is that `set-cookie` is the one response header that must not be folded into
a single line, so a response may carry several of them, while a map holds one value per
name. Cowboy keeps cookies in the request's `resp_cookies` field and fills the map key
itself at reply time, giving it a list value that each protocol expands into one header
per cookie (`cowboy_http:headers_to_list/1`, `cowboy_http2:headers_to_list/1`).

So the key is reserved and type-overloaded. A handler that returns a plain binary there
exits with `response_error` on cowboy 2.10 and later. On 2.9, which this repo builds
against, there is no guard: the value reaches `headers_to_list/1`, the list comprehension
gets a binary generator and raises `bad_generator` in the connection process, and a
cookie set earlier on the request is silently clobbered by `response_headers/2`.

This moves any `set-cookie` entry out of the header map into `resp_cookies` before
replying, which is the translation cowboy expects a framework layered on it to do.

## Interface

Return the formatted cookie under the lower case `set-cookie` key:

```erlang
login(post, _Params) ->
    Cookie = iolist_to_binary(
        cow_cookie:setcookie(<<"session">>, Token, #{path => <<"/api">>, http_only => true})
    ),
    {200, #{<<"set-cookie">> => Cookie}, #{}}.
```

The value is one cookie as a binary, or several as a list of binaries, each already
formatted by `cow_cookie:setcookie/3`. Anything else raises
`{invalid_set_cookie_header, Value}` at the point of the mistake, rather than deep in the
protocol. Cookies are keyed by name, as cowboy does, so setting the same cookie twice
replaces it instead of sending two headers the browser cannot reconcile, and a cookie a
middleware already set on the request is preserved.

The header name must be lower case. That matches how cowboy keys headers, and HTTP/2
requires it. A differently cased key passes through as an ordinary header, exactly as it
does today.

## Compatibility

Handlers that do not return `set-cookie` are unaffected: one extra `maps:take/2` per
response. Handlers that do return it currently crash, so there is no behaviour to keep.

## Tests

`t_set_cookie` and `t_set_cookies` in `minirest_handler_SUITE` drive real requests through
the listener and assert the cookies arrive as separate `set-cookie` headers. The
assertions check the `name=value` pair and the requested attributes rather than the whole
string, because the attribute list differs between cowlib versions (2.9's cowlib appends
`Version=1`).

`make ct` (13 passed), `make xref` and `make fmt-check` are clean on OTP 27.2.

## Why

Needed by an EMQX Dashboard SSO fix that binds each OIDC and SAML login round-trip to the
browser that started it with a login-start cookie checked at the callback. There is no
route from a minirest handler to a cookie without this.
